### PR TITLE
Add dual ECDH example

### DIFF
--- a/pyrelic/tests/test_schemes.py
+++ b/pyrelic/tests/test_schemes.py
@@ -1,0 +1,51 @@
+# Copyright 2021 Sebastian Ramacher <sebastian.ramacher@ait.ac.at>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import unittest
+import pyrelic
+from pyrelic import G1, G2, GT
+
+class TestSchemes:
+    def test_dual_dhke(self):
+        #use case: https://engineering.fb.com/2020/07/10/open-source/private-matching/
+        s1 = pyrelic.rand_BN_order()
+        s2 = pyrelic.rand_BN_order()
+
+        ids = [b"some id", b"your name"]
+
+        for i in ids:
+            p = self.hash_to_curve(i)
+            p1 = p**s1
+            p2 = p1**s2
+
+            p1_ = p**s2
+            p2_ = p1_**s1
+
+            self.assertEqual(p2, p2_)
+
+class G1(TestSchemes, unittest.TestCase):
+    def hash_to_curve(self, msg):
+        return pyrelic.hash_to_G1(msg)
+
+class G2(TestSchemes, unittest.TestCase):
+    def hash_to_curve(self, msg):
+        return pyrelic.hash_to_G2(msg)
+
+


### PR DESCRIPTION
@sebastinas, I expose on_curve_G1 and on_curve_G2, and add a test for dual ECDH which is used here https://engineering.fb.com/2020/07/10/open-source/private-matching/